### PR TITLE
Feat(patient-bills): Implement frontend for PDF receipt download

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, ErrorHandler, inject } from '@angular/core';
+import { ApplicationConfig, ErrorHandler, inject, LOCALE_ID } from '@angular/core';
 import { provideRouter, withComponentInputBinding, withViewTransitions } from '@angular/router';
 import { routes } from './app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -6,6 +6,14 @@ import { authInterceptor } from './core/interceptors';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
 import { LoggingService } from './shared/services/loggin.service'; // FIXED: Updated import path
+
+
+// Import French locale data
+import { registerLocaleData } from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
+
+// Register the French locale data.
+registerLocaleData(localeFr);
 
 // Custom error handler to log detailed errors
 export class GlobalErrorHandler implements ErrorHandler {
@@ -35,6 +43,8 @@ export const appConfig: ApplicationConfig = {
     provideAnimations(),
     LoggingService,
     { provide: ErrorHandler, useClass: GlobalErrorHandler },
-    { provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: { hasBackdrop: true } }
+    { provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: { hasBackdrop: true } },
+    { provide: LOCALE_ID, useValue: 'fr-FR' }
+  
   ]
 };

--- a/src/app/core/patient/domain/models/bill.model.ts
+++ b/src/app/core/patient/domain/models/bill.model.ts
@@ -1,42 +1,80 @@
-export interface ServiceRendered {
+// filepath: c:\Users\Microsoft\Documents\portail\Template_ASIO\src\app\core\patient\domain\models\bill.model.ts
+export interface BillItem {
+  id: number;
+  bill_id: number;
+  service_type: string; // e.g., "CONSULT", "PHYSIO"
+  description: string; // Detailed description of the service
+  price: number; // Unit price
+  quantity?: number; // Quantity, might be optional or not present in all contexts
+  total: number; // Total price for this item
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface DoctorInfo {
   id: number;
   name: string;
-  quantity: number;
-  unit_price: number;
-  total_price: number;
+  specialty?: string | null; // Specialty might be optional
+  email?: string; // from list example
 }
 
 export interface Bill {
-  id: number; // N° Facture
-  patient_id: number;
-  amount: number; // Montant
-  issue_date: string; // Date (YYYY-MM-DD)
-  due_date: string;   // YYYY-MM-DD
-  status: string; // Status (ex: "paid")
-  notes: string | null;
-  pdf_link: string | null; // Lien direct vers le PDF via la route de téléchargement
+  id: number; // Numerical ID of the bill
+  patient_id?: number; // Optional, as it's contextually known for patient's bills
+  doctor_user_id?: number;
+  bill_number: string; // User-facing bill number, e.g., "BILL-20241107..."
+  amount: number; // Total amount of the bill
+  issue_date: string; // Date string (e.g., "YYYY-MM-DD" or ISO string)
+  due_date?: string | null; // Optional, may not be in all responses
+  // status: string; // Removed as it's not in the new API response
+  description: string | null; // General description or notes for the bill
+  pdf_path: string | null; // Path or link to the PDF
+  payment_method: string | null;
   created_at: string;
   updated_at: string;
+  created_by_user_id?: number;
 
-  // Données fournies par le backend
-  doctor_name: string | null;
-  doctor_specialty: string | null;
-  payment_method: string | null;
-  services_rendered: ServiceRendered[];
+  doctor: DoctorInfo;
+  items: BillItem[]; // Renamed from services_rendered and structure updated
+
+  // Fields that were in the old model but might not be directly in the new root
+  // doctor_name: string | null; // Now under doctor.name
+  // doctor_specialty: string | null; // Now under doctor.specialty
 }
 
-export interface PaginatedResponse<T> {
+export interface BackendPagination {
+  total: number;
+  current_page: number;
+  per_page: number;
+  last_page: number;
+  from?: number; // Assuming these might be available
+  to?: number;
+  first_page_url?: string;
+  last_page_url?: string;
+  next_page_url?: string | null;
+  prev_page_url?: string | null;
+  path?: string;
+  links?: { url: string | null; label: string; active: boolean }[];
+}
+
+export interface PaginatedBillResponse {
+  items: Bill[];
+  pagination: BackendPagination;
+}
+
+// This is the structure the frontend components will expect after service mapping
+export interface FrontendPaginatedResponse<T> {
   data: T[];
   current_page: number;
-  first_page_url: string;
-  from: number;
+  first_page_url?: string;
+  from?: number;
   last_page: number;
-  last_page_url: string;
-  links: { url: string | null; label: string; active: boolean }[];
+  last_page_url?: string;
+  links?: { url: string | null; label: string; active: boolean }[];
   next_page_url: string | null;
-  path: string;
+  path?: string;
   per_page: number;
   prev_page_url: string | null;
-  to: number;
+  to?: number;
   total: number;
 }

--- a/src/app/core/patient/services/bill.service.ts
+++ b/src/app/core/patient/services/bill.service.ts
@@ -1,44 +1,120 @@
+// filepath: c:\Users\Microsoft\Documents\portail\Template_ASIO\src\app\core\patient\services\bill.service.ts
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
+import { Bill, FrontendPaginatedResponse, PaginatedBillResponse } from '../domain/models/bill.model';
 
- 
-import { Bill, PaginatedResponse } from '../domain/models/bill.model';
 
+// Define new filters based on backend capabilities for /patient/bills
+// The backend controller for getMyBills only shows: 'date_from', 'date_to', 'sort_by', 'sort_direction'
 export interface BillFilters {
   page?: number;
   per_page?: number;
   date_from?: string;
   date_to?: string;
- sort_by?: 'issue_date' | 'amount' | 'status' | 'due_date' | 'doctor_name';
+  sort_by?: 'issue_date' | 'amount' | 'doctor_name' | 'bill_number'; // Adjusted sortable fields
   sort_direction?: 'asc' | 'desc';
-  status?: string; 
+  // status?: string; // Status filter removed as per new API
+}
+
+interface BackendResponse<T> {
+  success: boolean;
+  message: string | null;
+  data: T;
 }
 
 @Injectable({
-  providedIn: 'root' 
+  providedIn: 'root'
 })
 export class BillService {
   private readonly API_BASE_URL = 'http://localhost:8000/api';
-  
+
   constructor(private http: HttpClient) { }
 
-  getBills(filters: BillFilters = {}): Observable<PaginatedResponse<Bill>> {
-    const url = `${this.API_BASE_URL}/bills/first-patient`;
+  getBills(filters: BillFilters = {}): Observable<FrontendPaginatedResponse<Bill>> {
+    const url = `${this.API_BASE_URL}/patient/bills`; // Updated endpoint
     let params = new HttpParams();
-      if (filters.page) params = params.set('page', filters.page.toString());
+
+    if (filters.page) params = params.set('page', filters.page.toString());
     if (filters.per_page) params = params.set('per_page', filters.per_page.toString());
     if (filters.date_from) params = params.set('date_from', filters.date_from);
     if (filters.date_to) params = params.set('date_to', filters.date_to);
     if (filters.sort_by) params = params.set('sort_by', filters.sort_by);
     if (filters.sort_direction) params = params.set('sort_direction', filters.sort_direction);
-    if (filters.status) params = params.set('status', filters.status);
+    // if (filters.status) params = params.set('status', filters.status); // Status filter removed
 
-    return this.http.get<PaginatedResponse<Bill>>(url, { params });
+    return this.http.get<BackendResponse<PaginatedBillResponse>>(url, { params }).pipe(
+      map(response => {
+        if (!response.success || !response.data) {
+          throw new Error(response.message || 'Failed to retrieve bills');
+        }
+        // Transform backend response to the structure frontend components expect
+        return {
+          data: response.data.items.map(bill => ({
+            ...bill,
+            amount: parseFloat(bill.amount as any) // Ensure amount is a number
+          })),
+          current_page: response.data.pagination.current_page,
+          from: response.data.pagination.from,
+          last_page: response.data.pagination.last_page,
+          next_page_url: response.data.pagination.next_page_url || null,
+          path: response.data.pagination.path,
+          per_page: response.data.pagination.per_page,
+          prev_page_url: response.data.pagination.prev_page_url || null,
+          to: response.data.pagination.to,
+          total: response.data.pagination.total,
+          first_page_url: response.data.pagination.first_page_url,
+          last_page_url: response.data.pagination.last_page_url,
+          links: response.data.pagination.links
+        };
+      })
+    );
   }
 
-  
-  getBillPdfByLink(pdfLink: string): Observable<Blob> {
-    return this.http.get(pdfLink, { responseType: 'blob' });
+  getBillDetails(billId: number): Observable<Bill> {
+    const url = `${this.API_BASE_URL}/patient/bills/${billId}`;
+    return this.http.get<BackendResponse<Bill>>(url).pipe(
+      map(response => {
+        if (!response.success || !response.data) {
+          throw new Error(response.message || `Failed to retrieve bill details for ID ${billId}`);
+        }
+        // Ensure amount and item prices/totals are numbers
+        const billData = response.data;
+        return {
+          ...billData,
+          amount: parseFloat(billData.amount as any),
+          items: billData.items.map(item => ({
+            ...item,
+            price: parseFloat(item.price as any),
+            total: parseFloat(item.total as any),
+          }))
+        };
+      })
+    );
   }
+
+  /**
+   * Downloads the PDF receipt for a specific bill for the authenticated patient.
+   * Uses the new dedicated patient receipt endpoint.
+   */
+  downloadPatientBillReceipt(billId: number): Observable<Blob> {
+    const url = `${this.API_BASE_URL}/patient/bills/${billId}/receipt`; // Corrected endpoint for patient receipt
+    return this.http.get(url, { responseType: 'blob' });
+  }
+
+
+   /**
+   * @deprecated Use downloadPatientBillReceipt for patient-specific downloads.
+   * This method might be for admin/staff if the /bills/{bill_id}/download-pdf endpoint is still used by them.
+   */
+  downloadBillPdf(billId: number): Observable<Blob> {
+    // This endpoint /bills/{bill_id}/download-pdf is likely for staff/admin.
+    // For patients, use downloadPatientBillReceipt.
+    // If this is indeed intended for other roles, it can remain.
+    // Otherwise, it should be updated or removed if patients only use the /receipt endpoint.
+    const url = `${this.API_BASE_URL}/bills/${billId}/download-pdf`; // Original endpoint
+    console.warn("downloadBillPdf is called. For patient receipts, consider using downloadPatientBillReceipt.");
+    return this.http.get(url, { responseType: 'blob' });
+  }
+
 }

--- a/src/app/features/patient/bills/bills.component.ts
+++ b/src/app/features/patient/bills/bills.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { Bill } from '../../../core/patient/domain/models/bill.model';
+import { Bill, FrontendPaginatedResponse } from '../../../core/patient/domain/models/bill.model';
 import { BillService } from '../../../core/patient/services/bill.service';
-import { Subject} from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { takeUntil, map, finalize } from 'rxjs/operators';
 
 interface SummaryCard {
   title: string;
@@ -20,6 +20,7 @@ export class BillsComponent implements OnInit, OnDestroy {
    summaryCards: SummaryCard[] = [];
   selectedBill: Bill | undefined = undefined;
   isLoadingSummary = true;
+ isLoadingDetail = false; // Ajout pour gérer le chargement du détail
 
   private allBillsForSummary: Bill[] = [];
   private destroy$ = new Subject<void>();
@@ -35,19 +36,24 @@ ngOnInit(): void {
 
   loadAllBillsForSummary(): void {
     this.isLoadingSummary = true;
-    // Pour les stats, on récupère les factures payées.
-    // Idéalement, un endpoint backend dédié aux statistiques serait mieux.
-    this.billService.getBills({ per_page: 1000, status: 'paid' }) // Récupère un grand nombre de factures payées
-      .pipe(takeUntil(this.destroy$))
+    // Pour les stats, on récupère toutes les factures du patient.
+    // Le filtrage par 'paid' n'est plus appliqué ici car l'API /patient/bills
+    // ne semble plus supporter le filtre de statut.
+    // Si un endpoint dédié aux statistiques existe ou si le filtrage est possible, ajustez ici.
+    this.billService.getBills({ per_page: 1000 }) // Récupère un grand nombre de factures
+      .pipe(
+        takeUntil(this.destroy$),
+        map((response: FrontendPaginatedResponse<Bill>) => response.data) // Extrait les données de la réponse paginée
+      )
       .subscribe({
-        next: (response: { data: Bill[] }) => {
-          this.allBillsForSummary = response.data;
+        next: (bills: Bill[]) => {
+          this.allBillsForSummary = bills;
           this.calculateSummaryCards();
           this.isLoadingSummary = false;
           this.cdr.detectChanges();
         },
 
-       error: (err) => {
+        error: (err) => {
           console.error("Erreur lors du chargement des factures pour le résumé:", err);
           this.isLoadingSummary = false;
           this.setDefaultSummaryCardsOnError();
@@ -55,43 +61,75 @@ ngOnInit(): void {
         }
       });
   }
-    calculateSummaryCards(): void {
-    const paidBills = this.allBillsForSummary;
+   calculateSummaryCards(): void {
+    // Le résumé est maintenant calculé sur toutes les factures récupérées,
+    // car le statut 'paid' n'est plus un critère de filtrage direct à ce niveau.
+    // Vous pourriez vouloir filtrer `this.allBillsForSummary` ici si le statut
+    // est disponible dans l'objet Bill (actuellement retiré du modèle).
+    const billsToSummarize = this.allBillsForSummary;
 
-    const totalCount = paidBills.length;
-    const totalAmount = paidBills.reduce((sum, bill) => sum + bill.amount, 0);
+    const totalCount = billsToSummarize.length;
+    const totalAmount = billsToSummarize.reduce((sum, bill) => sum + bill.amount, 0);
 
     let latestBillDate = 'N/A';
-    if (paidBills.length > 0) {
-      const sortedBills = [...paidBills].sort((a, b) => new Date(b.issue_date).getTime() - new Date(a.issue_date).getTime());
+    if (billsToSummarize.length > 0) {
+      const sortedBills = [...billsToSummarize].sort((a, b) => {
+        const dateA = new Date(a.issue_date).getTime();
+        const dateB = new Date(b.issue_date).getTime();
+        return dateB - dateA;
+      });
       if (sortedBills[0]?.issue_date) {
         latestBillDate = new Date(sortedBills[0].issue_date).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' });
       }
     }
-
-    this.summaryCards = [
+this.summaryCards = [
       { title: 'Total des factures', value: totalCount, icon: 'receipt_long', colorClass: 'bg-blue-100 text-blue-600' },
-      { title: 'Montant total', value: `${totalAmount.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}`, icon: 'payments', colorClass: 'bg-green-100 text-green-600' },
-      { title: 'Dernière facture', value: latestBillDate, icon: 'event_note', colorClass: 'bg-orange-100 text-orange-600' },
+      { title: 'Montant total facturé', value: `${totalAmount.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}`, icon: 'payments', colorClass: 'bg-green-100 text-green-600' },
+      { title: 'Dernière facture émise', value: latestBillDate, icon: 'event_note', colorClass: 'bg-orange-100 text-orange-600' },
     ];
   }
 
-  setDefaultSummaryCardsOnError(): void {
+
+ setDefaultSummaryCardsOnError(): void {
     this.summaryCards = [
       { title: 'Total des factures', value: 'N/A', icon: 'receipt_long', colorClass: 'bg-blue-100 text-blue-600' },
-      { title: 'Montant total', value: 'N/A', icon: 'payments', colorClass: 'bg-green-100 text-green-600' },
-      { title: 'Dernière facture', value: 'N/A', icon: 'event_note', colorClass: 'bg-orange-100 text-orange-600' },
+      { title: 'Montant total facturé', value: 'N/A', icon: 'payments', colorClass: 'bg-green-100 text-green-600' },
+      { title: 'Dernière facture émise', value: 'N/A', icon: 'event_note', colorClass: 'bg-orange-100 text-orange-600' },
     ];
-     }
-
-  onBillSelectedForDetail(bill: Bill | undefined): void {
-    this.selectedBill = bill;
-    this.cdr.detectChanges();
-    if (bill) {
-      const detailElement = document.getElementById('billDetailSection');
-      detailElement?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
   }
+
+   onBillSelectedForDetail(bill: Bill | undefined): void {
+    if (bill && bill.id) {
+      this.isLoadingDetail = true;
+      this.selectedBill = undefined; // Optionnel: réinitialiser pour montrer un chargement
+      this.billService.getBillDetails(bill.id)
+        .pipe(
+          takeUntil(this.destroy$),
+          finalize(() => {
+            this.isLoadingDetail = false;
+            this.cdr.detectChanges();
+            if (this.selectedBill) { // S'assurer que selectedBill est défini avant de scroller
+              const detailElement = document.getElementById('billDetailSection');
+              detailElement?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          })
+        )
+        .subscribe({
+          next: (detailedBill) => {
+            this.selectedBill = detailedBill as Bill;
+          },
+          error: (err) => {
+            console.error('Erreur lors du chargement des détails de la facture:', err);
+            // Gérer l'erreur, par exemple afficher un message à l'utilisateur
+            this.selectedBill = undefined; // Ou garder l'ancien `bill` partiel si préférable
+          }
+        });
+    } else {
+      this.selectedBill = undefined;
+      this.isLoadingDetail = false; // S'assurer que isLoadingDetail est réinitialisé
+      this.cdr.detectChanges();
+    }
+  } 
 
   ngOnDestroy(): void {
     this.destroy$.next();

--- a/src/app/features/patient/bills/components/bill-detail/bill-detail.component.html
+++ b/src/app/features/patient/bills/components/bill-detail/bill-detail.component.html
@@ -1,17 +1,19 @@
+ 
 <div *ngIf="bill" class="bg-card shadow-xl rounded-card p-6 sm:p-card-padding font-sans sticky top-6 max-h-[calc(100vh-3rem)] overflow-y-auto">
   <!-- En-tête de la facture -->
   <div class="pb-5 mb-6 border-b border-border">
-    <h2 class="text-xl sm:text-2xl font-bold text-primary font-display mb-1">Facture #{{ bill.id }}</h2>
+    <h2 class="text-xl sm:text-2xl font-bold text-primary font-display mb-1">Facture {{ bill.bill_number }}</h2>
     <p class="text-sm text-text-light">Émise le: {{ bill.issue_date | date:'dd MMMM yyyy':'':'fr-FR' }}</p>
   </div>
 
-  <!-- Informations Clés: Montant et Statut -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6 p-5 bg-primary/5 dark:bg-primary/10 rounded-lg">
+  <!-- Informations Clés: Montant -->
+  <div class="grid grid-cols-1 sm:grid-cols-1 gap-6 mb-6 p-5 bg-primary/5 dark:bg-primary/10 rounded-lg"> <!-- Adjusted for single column if status is removed -->
     <div>
       <dt class="text-xs font-medium text-primary uppercase tracking-wider">Montant Total</dt>
       <dd class="mt-1 text-3xl font-semibold text-primary font-display">{{ bill.amount | currency:'EUR':'symbol':'1.2-2':'fr-FR' }}</dd>
     </div>
-    <div class="sm:text-right">
+    <!-- Status Display Removed -->
+    <!-- <div class="sm:text-right">
       <dt class="text-xs font-medium text-text-muted uppercase tracking-wider">Statut</dt>
       <dd class="mt-1">
         <span class="px-3 py-1 inline-flex text-sm leading-5 font-semibold rounded-full"
@@ -24,7 +26,7 @@
           {{ bill.status | titlecase }}
         </span>
       </dd>
-    </div>
+    </div> -->
   </div>
 
   <!-- Détails Généraux de la Facture -->
@@ -32,24 +34,28 @@
     <h3 class="text-section-header text-text mb-4">Informations Générales</h3>
     <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5 text-sm">
       <div>
-        <dt class="font-medium text-text-muted">N° Facture:</dt>
+        <dt class="font-medium text-text-muted">N° Facture (ID):</dt>
         <dd class="text-text mt-0.5">{{ bill.id ?? 'N/A' }}</dd>
+      </div>
+      <div>
+        <dt class="font-medium text-text-muted">N° Document:</dt>
+        <dd class="text-text mt-0.5">{{ bill.bill_number ?? 'N/A' }}</dd>
       </div>
       <div>
         <dt class="font-medium text-text-muted">Date d'émission:</dt>
         <dd class="text-text mt-0.5">{{ bill.issue_date | date:'dd/MM/yyyy' }}</dd>
       </div>
-      <div>
+      <div *ngIf="bill.due_date">
         <dt class="font-medium text-text-muted">Date d'échéance:</dt>
         <dd class="text-text mt-0.5">{{ bill.due_date | date:'dd/MM/yyyy' }}</dd>
       </div>
       <div>
         <dt class="font-medium text-text-muted">Médecin:</dt>
-        <dd class="text-text mt-0.5">{{ bill.doctor_name || 'N/A' }}</dd>
+        <dd class="text-text mt-0.5">{{ bill.doctor?.name || 'N/A' }}</dd>
       </div>
       <div>
         <dt class="font-medium text-text-muted">Spécialité:</dt>
-        <dd class="text-text mt-0.5">{{ bill.doctor_specialty || 'N/A' }}</dd>
+        <dd class="text-text mt-0.5">{{ bill.doctor?.specialty || 'N/A' }}</dd>
       </div>
       <div class="md:col-span-2">
         <dt class="font-medium text-text-muted">Mode de paiement:</dt>
@@ -59,46 +65,48 @@
   </div>
 
   <!-- Section Actes Réalisés -->
-  <div *ngIf="bill.services_rendered && bill.services_rendered.length > 0" class="mt-6 pt-6 border-t border-border">
+  <div *ngIf="bill.items && bill.items.length > 0" class="mt-6 pt-6 border-t border-border">
     <h3 class="text-section-header text-text mb-4">Actes Réalisés</h3>
     <div class="overflow-x-auto rounded-lg border border-border shadow-sm">
       <table class="min-w-full text-sm">
         <thead class="bg-background dark:bg-gray-700">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider">Acte</th>
-            <th class="px-4 py-3 text-right text-xs font-semibold text-text-muted uppercase tracking-wider">Qté</th>
+            <th class="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider">Description</th>
+            <th *ngIf="bill.items[0]?.quantity !== undefined" class="px-4 py-3 text-right text-xs font-semibold text-text-muted uppercase tracking-wider">Qté</th>
             <th class="px-4 py-3 text-right text-xs font-semibold text-text-muted uppercase tracking-wider">Prix Unit.</th>
             <th class="px-4 py-3 text-right text-xs font-semibold text-text-muted uppercase tracking-wider">Total</th>
           </tr>
         </thead>
         <tbody class="bg-card divide-y divide-border">
-          <tr *ngFor="let service of bill.services_rendered" class="hover:bg-hover dark:hover:bg-gray-700/30 transition-colors">
-            <td class="px-4 py-3 text-text text-left whitespace-normal">{{ service.name | titlecase }}</td>
-            <td class="px-4 py-3 text-text text-right">{{ service.quantity }}</td>
-            <td class="px-4 py-3 text-text text-right">{{ service.unit_price | currency:'EUR':'symbol':'1.2-2':'fr-FR' }}</td>
-            <td class="px-4 py-3 text-text text-right font-semibold">{{ service.total_price | currency:'EUR':'symbol':'1.2-2':'fr-FR' }}</td>
+          <tr *ngFor="let item of bill.items" class="hover:bg-hover dark:hover:bg-gray-700/30 transition-colors">
+            <td class="px-4 py-3 text-text text-left whitespace-normal">
+              <span class="font-medium">{{ item.service_type | titlecase }}</span>: {{ item.description | titlecase }}
+            </td>
+            <td *ngIf="item.quantity !== undefined" class="px-4 py-3 text-text text-right">{{ item.quantity }}</td>
+            <td class="px-4 py-3 text-text text-right">{{ item.price | currency:'EUR':'symbol':'1.2-2':'fr-FR' }}</td>
+            <td class="px-4 py-3 text-text text-right font-semibold">{{ item.total | currency:'EUR':'symbol':'1.2-2':'fr-FR' }}</td>
           </tr>
         </tbody>
       </table>
     </div>
   </div>
 
-  <!-- Section Notes -->
-  <div *ngIf="bill.notes" class="mt-6 pt-6 border-t border-border">
-    <h3 class="text-section-header text-text mb-3">Notes</h3>
+  <!-- Section Notes/Description -->
+  <div *ngIf="bill.description" class="mt-6 pt-6 border-t border-border">
+    <h3 class="text-section-header text-text mb-3">Description / Notes</h3>
     <div class="p-4 bg-background dark:bg-gray-700/50 rounded-md text-sm text-text-light whitespace-pre-wrap">
-      {{ bill.notes }}
+      {{ bill.description }}
     </div>
   </div>
 
   <!-- Actions -->
   <div class="mt-8 pt-6 border-t border-border flex flex-col sm:flex-row justify-end gap-3">
-    <button *ngIf="bill.pdf_link" (click)="downloadPdfFromDetail()"
+    <button *ngIf="bill.pdf_path !== null" (click)="downloadPdfFromDetail()"
             class="w-full sm:w-auto inline-flex items-center justify-center px-6 py-2.5 border border-transparent text-sm font-medium rounded-button shadow-sm text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-colors duration-150">
       <span class="material-icons-outlined mr-2 text-lg">download</span>
       Télécharger PDF
     </button>
-    <p *ngIf="!bill.pdf_link && bill" class="text-sm text-text-light italic text-center sm:text-right py-2">
+    <p *ngIf="bill.pdf_path === null && bill" class="text-sm text-text-light italic text-center sm:text-right py-2">
       Aucun PDF disponible pour cette facture.
     </p>
   </div>

--- a/src/app/features/patient/bills/components/bill-detail/bill-detail.component.ts
+++ b/src/app/features/patient/bills/components/bill-detail/bill-detail.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Bill } from '../../../../../core/patient/domain/models/bill.model';
+import { BillService } from '../../../../../core/patient/services/bill.service';
  
  
 @Component({
@@ -11,12 +12,37 @@ import { Bill } from '../../../../../core/patient/domain/models/bill.model';
 export class BillDetailComponent {
 @Input() bill: Bill | undefined = undefined;
 
-  constructor() { }
+  constructor(private billService: BillService) { } // Inject BillService
 
   downloadPdfFromDetail(): void {
-    if (this.bill?.pdf_link) {
-      window.open(this.bill.pdf_link, '_blank');
+    // The bill object in detail view might have pdf_path, but for consistency and
+    // to ensure the latest version is always fetched from the /receipt endpoint,
+    // we'll use the bill ID.
+    if (this.bill && this.bill.id) {
+      this.billService.downloadPatientBillReceipt(this.bill.id).subscribe({ // Use the new service method
+        next: blob => {
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `Recu-${this.bill?.bill_number || this.bill?.id}.pdf`; // Changed to "Recu-"
+          document.body.appendChild(a);
+          a.click();
+          window.URL.revokeObjectURL(url);
+          a.remove();
+        },
+         error: error => {
+          console.error('Erreur de téléchargement du reçu PDF depuis détail:', error);
+          let errorMessage = "Erreur lors du téléchargement du PDF.";
+          if (error.status === 403) {
+            errorMessage = "Vous n'êtes pas autorisé à télécharger ce reçu.";
+          } else if (error.status === 404) {
+            errorMessage = "Reçu non trouvé.";
+          }
+          alert(errorMessage);
+        }
+      });
+    } else {
+      alert("ID de facture manquant, impossible de télécharger le PDF.");
     }
   }
-
 }

--- a/src/app/features/patient/bills/components/bill-list/bill-list.component.html
+++ b/src/app/features/patient/bills/components/bill-list/bill-list.component.html
@@ -1,15 +1,17 @@
+ 
 <div class="bg-card shadow-card rounded-card p-card-padding font-sans">
   <!-- Section des Filtres -->
   <div class="mb-card-margin p-card-padding border border-border rounded-card bg-background">
     <h3 class="text-section-header text-text mb-5">Filtrer les Factures</h3>
     <form (ngSubmit)="applyFilters()" #filterForm="ngForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 items-end">
-      <div>
+      <!-- Statut Filter Removed -->
+      <!-- <div>
         <label for="statusFilterList" class="block text-sm font-medium text-text-light mb-1.5">Statut</label>
         <select id="statusFilterList" name="statusFilterList" [(ngModel)]="filters.status" class="mt-1 block w-full py-2.5 px-3.5 border border-border bg-card rounded-input shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm text-text">
           <option value="">Tous</option>
           <option *ngFor="let statusOpt of statusOptions" [value]="statusOpt">{{ statusOpt | titlecase }}</option>
         </select>
-      </div>
+      </div> -->
       <div>
         <label for="dateFromFilterList" class="block text-sm font-medium text-text-light mb-1.5">Date d'émission (De)</label>
         <input type="date" id="dateFromFilterList" name="dateFromFilterList" [(ngModel)]="filters.date_from" class="mt-1 block w-full py-2.5 px-3.5 border border-border bg-card rounded-input shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm text-text">
@@ -18,7 +20,7 @@
         <label for="dateToFilterList" class="block text-sm font-medium text-text-light mb-1.5">Date d'émission (À)</label>
         <input type="date" id="dateToFilterList" name="dateToFilterList" [(ngModel)]="filters.date_to" class="mt-1 block w-full py-2.5 px-3.5 border border-border bg-card rounded-input shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm text-text">
       </div>
-      <div class="md:col-span-2 lg:col-span-1 flex space-x-3 mt-4 md:mt-0 lg:self-end">
+      <div class="md:col-span-1 lg:col-span-1 flex space-x-3 mt-4 md:mt-0 lg:self-end md:col-start-2 lg:col-start-3">
         <button type="submit" class="flex-1 inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-button text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-colors duration-150">
           <span class="material-icons-outlined text-lg mr-2">filter_list</span>Appliquer
         </button>
@@ -60,11 +62,12 @@
         <tr *ngFor="let bill of billsResponse.data; trackBy: trackByBillId"
             [ngClass]="{'bg-primary/5 dark:bg-primary/10': bill.id === currentSelectedBillId }"
             class="hover:bg-hover dark:hover:bg-gray-700/30 transition-colors duration-150 cursor-pointer" (click)="viewBillDetails(bill)">
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-text font-medium">#{{ bill.id }}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-text font-medium">{{ bill.bill_number }}</td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-text">{{ bill.issue_date | date:'dd/MM/yyyy' }}</td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-text">{{ bill.doctor_name || 'N/A' }}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-text">{{ bill.doctor?.name || 'N/A' }}</td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-text text-right font-medium">{{ bill.amount | currency:'EUR':'symbol':'1.2-2' }}</td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm">
+          <!-- Status Column Removed -->
+          <!-- <td class="px-6 py-4 whitespace-nowrap text-sm">
             <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full"
                   [ngClass]="{
                     'bg-status-success/20 text-status-success': bill.status === 'paid',
@@ -74,17 +77,18 @@
                   }">
               {{ bill.status | titlecase }}
             </span>
-          </td>
+          </td> -->
           <td class="px-6 py-4 whitespace-nowrap text-sm text-center space-x-1">
             <button (click)="viewBillDetails(bill); $event.stopPropagation()" title="Voir détails" class="text-primary hover:text-primary-dark p-1.5 rounded-full hover:bg-primary/10 focus:outline-none transition-colors duration-150">
               <span class="material-icons-outlined text-xl">visibility</span>
             </button>
-            <button *ngIf="bill.pdf_link" (click)="downloadBillPdf(bill, $event); $event.stopPropagation()" title="Télécharger PDF" class="text-accent hover:text-accent-dark p-1.5 rounded-full hover:bg-accent/10 focus:outline-none transition-colors duration-150">
-              <span class="material-icons-outlined text-xl">download</span>
-            </button>
-            <span *ngIf="!bill.pdf_link" class="text-text-muted p-1.5 inline-block align-middle" title="PDF non disponible">
-                <span class="material-icons-outlined text-xl">file_download_off</span>
-            </span>
+
+                 <button *ngIf="bill.id" (click)="downloadBillPdf(bill, $event); $event.stopPropagation()" title="Télécharger Reçu" class="text-accent hover:text-accent-dark p-1.5 rounded-full hover:bg-accent/10 focus:outline-none transition-colors duration-150">
+            <span class="material-icons-outlined text-xl">download</span>
+          </button>
+            <!-- <span *ngIf="bill.pdf_path === null" class="text-text-muted p-1.5 inline-block align-middle" title="PDF non disponible"> -->
+                <!-- <span class="material-icons-outlined text-xl">file_download_off</span>
+            </span> -->
           </td>
         </tr>
       </tbody>
@@ -101,7 +105,8 @@
     <div>
       <p class="text-sm text-text-light">
         Page <span class="font-medium text-text">{{ billsResponse.current_page }}</span> sur <span class="font-medium text-text">{{ billsResponse.last_page }}</span>
-        <span class="hidden sm:inline"> - Affichage de {{ billsResponse.from }}-{{ billsResponse.to }} sur {{ billsResponse.total }}</span>
+        <span *ngIf="billsResponse.from && billsResponse.to" class="hidden sm:inline"> - Affichage de {{ billsResponse.from }}-{{ billsResponse.to }} sur {{ billsResponse.total }}</span>
+        <span *ngIf="!billsResponse.from || !billsResponse.to" class="hidden sm:inline"> - Total de {{ billsResponse.total }}</span>
       </p>
     </div>
     <nav class="relative z-0 inline-flex rounded-button shadow-sm -space-x-px" aria-label="Pagination">


### PR DESCRIPTION
Integrates frontend functionality to allow patients to download their bill receipts as PDF files.

- Updates BillService with a new method to call the dedicated '/patient/bills/{id}/receipt' endpoint.
- Modifies BillListComponent and BillDetailComponent to use the new service method, removing dependency on 'pdf_path'.
- Adjusts component templates to reflect on-demand PDF generation and updates download button logic.
- Standardizes downloaded PDF filenames and improves error handling.