### PR TITLE
feat(patient): Add file upload functionality for patient

### DIFF
--- a/src/app/core/patient/services/patient-file.service.ts
+++ b/src/app/core/patient/services/patient-file.service.ts
@@ -48,6 +48,17 @@ export class PatientFileService {
       map(response => response.data)
     );
   }
+    /**
+   * Upload a file for the currently authenticated patient.
+   * ✅ NOUVELLE MÉTHODE
+   */
+  uploadFileForPatient(formData: FormData): Observable<PatientFile> {
+    // Note: This FormData should NOT contain a patient_id
+    return this.http.post<SinglePatientFileApiResponse>(`${environment.apiUrl}/patient/files`, formData).pipe(
+      map(response => response.data)
+    );
+  }
+  
 
   updateFile(id: number, data: { description?: string; category?: string }): Observable<PatientFile> {
     const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');

--- a/src/app/features/patient/medical-record/components/patient-files/patient-files.component.ts
+++ b/src/app/features/patient/medical-record/components/patient-files/patient-files.component.ts
@@ -225,9 +225,9 @@ export class PatientFilesComponent implements OnInit {
     formData.append('file', this.selectedFile, this.selectedFile.name);
     formData.append('category', this.uploadForm.value.category);
     formData.append('description', this.uploadForm.value.description || '');
-    formData.append('patient_id', '19');
+ 
 
-    this.fileService.uploadFile(formData).subscribe({
+    this.fileService.uploadFileForPatient(formData).subscribe({
       next: (newFile) => {
         this.files.unshift(newFile);
         this.toastService.success('File uploaded successfully!');


### PR DESCRIPTION
This commit introduces the ability for an authenticated patient to upload files to their medical record.

- Added a new `uploadFileForPatient` method in `patient-file.service.ts` which communicates with the new API route `/patient/files`.
- Updated `patient-files.component.ts` to use this new method, ensuring that the `patient_id` is no longer sent manually.
- The component s logic has been adapted to handle the upload process through